### PR TITLE
Add devcontainer with documentation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "npm install",
+
+	// Configure tool-specific properties.
+	// Uncomment to install VS Code extensions for vue, tailwind and prettier.
+	// "customizations": {
+	// 	"vscode": {
+	// 		"extensions": [
+	// 			"Vue.volar",
+	// 			"bradlc.vscode-tailwindcss",
+	// 			"esbenp.prettier-vscode"
+	// 		]
+	// 	}
+	// },
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+
+	// Disable IPv6 to avoid issues with vite dev, see https://github.com/vitejs/vite/issues/16522#issuecomment-2084322973
+	"runArgs": [ "--sysctl", "net.ipv6.conf.all.disable_ipv6=1"]
+}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ This project provides a boilerplate for building your own extension for [ChurchT
     npm install
     ```
 
+### Optional: Using Dev Container
+
+This project includes a dev container configuration. If you use VS Code with the "Dev Containers" extension, you can:
+
+1. Clone the repository
+2. Open it in VS Code
+3. Click the Remote Indicator in the bottom-left corner of VS Code status bar
+4. Select "Reopen in Container"
+
+The container includes the tools mentioned in the prerequisites pre-installed and also runs `npm install` on startup.
+
 ## Configuration
 
 Copy `.env-example` to `.env` and fill in your data.


### PR DESCRIPTION
Adds VS Code devcontainer configuration for a consistent development environment with:

- Node.js & TypeScript pre-installed
- Automatic `npm install` on container creation
- IPv6 disabled to avoid Vite dev server issues (see https://github.com/vitejs/vite/issues/16522#issuecomment-2084322973 )
- Documentation added to README

This change makes it easier to get started without manually installing dependencies.