### PR TITLE
Fix createCustomDataValue return type in kv-store

### DIFF
--- a/key-value-store.md
+++ b/key-value-store.md
@@ -154,17 +154,18 @@ const values = await getCustomDataValues<UserSettings>(categoryId);
 const bgColor = values.find(v => v.key === 'backgroundColor');
 ```
 
-#### `createCustomDataValue(payload: CustomModuleDataValueCreate, moduleId?: number): Promise<void>`
+#### `createCustomDataValue(payload: CustomModuleDataValueCreate, moduleId?: number): Promise<CustomModuleDataValue>`
 
 Creates a new value in a category.
 
 ```typescript
 import { createCustomDataValue } from '../utils/kv-store';
 
-await createCustomDataValue({
+const newValue = await createCustomDataValue({
     dataCategoryId: categoryId,
     value: JSON.stringify({ key: 'theme', value: 'dark' }),
 });
+console.log('Created value with ID:', newValue.id);
 ```
 
 #### `updateCustomDataValue(categoryId: number, valueId: number, payload: Partial<CustomModuleDataValue>, moduleId?: number): Promise<void>`

--- a/src/utils/kv-store.ts
+++ b/src/utils/kv-store.ts
@@ -238,13 +238,14 @@ export async function getCustomDataValues<T extends object>(
  * Create a new custom data value
  * implements POST `/custommodules/{moduleId}/customdatacategories/{dataCategoryId}/customdatavalues`
  * @param moduleId - optional module id - otherwise tries default
+ * @returns - the created custom data value
  */
 export async function createCustomDataValue(
     payload: CustomModuleDataValueCreate,
     moduleId?: number,
-): Promise<void> {
+): Promise<CustomModuleDataValue> {
     moduleId = await resolveModuleId(moduleId);
-    const newValue: string = await churchtoolsClient.post(
+    const newValue: CustomModuleDataValue = await churchtoolsClient.post(
         `/custommodules/${moduleId}/customdatacategories/${payload.dataCategoryId}/customdatavalues`,
         payload,
     );
@@ -252,6 +253,7 @@ export async function createCustomDataValue(
         `Created data value in category ${payload.dataCategoryId}:`,
         newValue,
     );
+    return newValue;
 }
 
 /**


### PR DESCRIPTION
- Changed return type from Promise-void to Promise-CustomModuleDataValue
- Fixed newValue type annotation from string to CustomModuleDataValue
- Added return statement to return the created value
- Updated documentation to reflect the correct return type

The function now correctly returns the created CustomModuleDataValue object with its id, matching the actual API response.